### PR TITLE
Fixed call to set_ee_transform to remove extra argument for env_idx

### DIFF
--- a/isaacgym_utils/rl/franka_vec_env.py
+++ b/isaacgym_utils/rl/franka_vec_env.py
@@ -237,8 +237,9 @@ class GymFrankaVecEnv(GymVecEnv):
                     self._frankas[env_idx].set_joints_targets(env_idx, self._franka_name, init_random_joints)
 
             if self._action_mode == 'vic':
-                self._frankas[env_idx].set_ee_transform(env_idx, env_idx, self._franka_name, 
-                                            self._init_ee_transforms[env_idx])
+                self._frankas[env_idx].set_ee_transform(
+                    env_idx, self._franka_name, self._init_ee_transforms[env_idx]
+                )
 
 
 class GymFrankaBlockVecEnv(GymFrankaVecEnv):


### PR DESCRIPTION
When running the example `python examples/franka_rl_vec_env.py` using `vic` actuation mode, I received the following error:
```
Traceback (most recent call last):
  File "examples/franka_rl_vec_env.py", line 20, in <module>
    def custom_draws(scene):
  File "/home/telee/ws/isaacgym-utils/isaacgym_utils/rl/vec_env.py", line 121, in reset
    self._reset(env_idxs)
  File "/home/telee/ws/isaacgym-utils/isaacgym_utils/rl/franka_vec_env.py", line 273, in _reset
    super()._reset(env_idxs)
  File "/home/telee/ws/isaacgym-utils/isaacgym_utils/rl/franka_vec_env.py", line 242, in _reset
    self._init_ee_transforms[env_idx])
TypeError: set_ee_transform() takes 4 positional arguments but 5 were given
```

This PR fixes the call to `set_ee_transform()` so it works now when in `vic`.