### PR TITLE
Improvements for attach_camera

### DIFF
--- a/isaacgym_utils/constants.py
+++ b/isaacgym_utils/constants.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pkg_resources
 from pathlib import Path
 import isaacgym
 import isaacgym_utils
@@ -10,6 +11,10 @@ isaacgym_ASSETS_PATH = isaacgym_PATH.parent / 'assets'
 
 isaacgym_utils_PATH = Path(isaacgym_utils.__file__).parent.parent
 isaacgym_utils_ASSETS_PATH = isaacgym_utils_PATH / 'assets'
+
+isaacgym_VERSION = pkg_resources.working_set.find(
+    pkg_resources.Requirement('isaacgym')
+    ).version
 
 # This is to convert between canonical cam frame and gym cam frame
 # Canonical cam frame is (z forward, x right, y down)


### PR DESCRIPTION
Fixes for `attach_camera` to work in both `1.0rc1` and `1.0rc2`. This fixes Issue #12.

In order to do this, I created a new variable `isaacgym_VERSION` which contains the version of IsaacGym being used. This is used in `attach_camera` to provide the proper argument to `attach_camera_to_body`.

I also added an optional `follow_position_only` flag to `attach_camera`, since it seemed straightforward to do and someone might need it. In this mode, only the camera position changes with the attached rigid body -- the orientation does not. (Like a gimbal.)