### PR TITLE
Calculate self._env_lower to retain behavior in rc1 and get correct behavior in rc2

### DIFF
--- a/isaacgym_utils/scene.py
+++ b/isaacgym_utils/scene.py
@@ -27,7 +27,6 @@ class GymScene:
             self._gym.viewer_camera_look_at(self._viewer, None, cam_pos, look_at)
 
         # create envs
-
         sim_up_axis = self._gym.get_sim_params(self._sim).up_axis
         if isaacgym_VERSION == '1.0rc1' or sim_up_axis == gymapi.UP_AXIS_Y:
             # In 1.0rc1, the 2nd element is always vertical, no matter the up axis setting


### PR DESCRIPTION
Fixes #15

Example of fixed code behavior. This is 1.0rc2 in `UP_AXIS_Z` mode.
![Screenshot from 2021-08-13 19-52-56](https://user-images.githubusercontent.com/45348789/129428148-78e2e267-f46f-4321-9112-ffb173c46f25.png)
