### PR TITLE
Added resolve to texture path

### DIFF
--- a/isaacgym_utils/assets/assets.py
+++ b/isaacgym_utils/assets/assets.py
@@ -155,7 +155,13 @@ class GymAsset(ABC):
                     self._scene.gym.set_rigid_body_color(env_ptr, ah, rb_idx, gymapi.MESH_VISUAL, np_to_vec3([1, 1, 1]))
                     # create and set texture
                     if rb_props[rb_idx]['texture'] not in self.GLOBAL_TEXTURES_CACHE:
-                        self.GLOBAL_TEXTURES_CACHE[rb_props[rb_idx]['texture']] = self._scene.gym.create_texture_from_file(self._scene.sim, str(self._assets_root / rb_props[rb_idx]['texture']))
+                        texture_path = str(
+                            (self._assets_root / rb_props[rb_idx]['texture']).resolve()
+                        )
+                        self.GLOBAL_TEXTURES_CACHE[rb_props[rb_idx]['texture']] = self._scene.gym.create_texture_from_file(
+                            self._scene.sim,
+                            texture_path,
+                        )
                     th = self.GLOBAL_TEXTURES_CACHE[rb_props[rb_idx]['texture']]
                     self._scene.gym.set_rigid_body_texture(env_ptr, ah, rb_idx, gymapi.MESH_VISUAL, th)
 


### PR DESCRIPTION
This PR allows the user to specify a relative path to a texture asset when the texture asset is _not_ located under `assets`.

Currently, Isaac Gym does not parse paths correctly when using the `../` shortcut with `create_texture_from_file`. For example, specifying a texture path in `set_rb_props` as `../path/to/texture.png` does not work, even if the texture exists in that location. However, resolving the path prior to calling `create_texture_from_file` works.

Without this PR, texture assets not located under `assets` appear to only be specifiable when providing absolute paths.