### PR TITLE
Feature optional cam cfg

### DIFF
--- a/isaacgym_utils/camera.py
+++ b/isaacgym_utils/camera.py
@@ -88,7 +88,7 @@ class GymCamera:
 
     def frames(self, env_idx, name, get_color=True, get_depth=True, get_seg=True, get_normal=True):
         assert get_color or get_depth or get_seg or get_normal
-        
+
         env_ptr = self._scene.env_ptrs[env_idx]
         ch = self._scene.ch_map[env_idx][name]
 
@@ -112,12 +112,12 @@ class GymCamera:
                 raw_depth = self._scene.gym.get_camera_image(self._scene.sim, env_ptr, ch, gymapi.IMAGE_DEPTH)
                 depth = _process_gym_depth(raw_depth)
                 depth_im = DepthImage(depth, frame=name)
-            
+
             normal = _make_normal_map(depth_im, self.get_intrinsics(name))
             frames['normal'] = NormalCloudImage(normal, frame=name)
-        
+
         return frames
-            
+
 
 def _process_gym_color(raw_im):
     return raw_im.flatten().reshape(raw_im.shape[0], raw_im.shape[1]//4, 4)[:, :, :3]
@@ -135,12 +135,12 @@ def _make_normal_map(depth, intr, inf_depth=100):
     depth = DepthImage(depth_data, frame=depth.frame)
 
     pts = intr.deproject_to_image(depth).data
-    
+
     A = pts[1:, :-1] - pts[:-1, :-1]
     B = pts[:-1, 1:] - pts[:-1, :-1]
     C = np.cross(A.reshape(-1, 3), B.reshape(-1, 3))
     D = C / np.linalg.norm(C, axis=1).reshape(-1, 1)
-    
+
     normal = np.zeros((depth.shape[0], depth.shape[1], 3))
     normal[:-1, :-1] = D.reshape(A.shape)
     normal[-1, :] = normal[-2, :]

--- a/isaacgym_utils/camera.py
+++ b/isaacgym_utils/camera.py
@@ -16,7 +16,8 @@ class GymCamera:
 
         self.gym_cam_props = gymapi.CameraProperties()
         for key, value in cam_props.items():
-            setattr(self.gym_cam_props, key, value)
+            if hasattr(self.gym_cam_props, key):
+                setattr(self.gym_cam_props, key, value)
 
         self._x_axis_rot = np.array([
             [1, 0, 0],


### PR DESCRIPTION
This PR implements the possibility of adding additional camera configuration options to the Isaac Gym config file that could be used by end user code but not necessarily Isaac Gym's gymapi.

For example,
```
camera:
  width: 640
  height: 480
  debug:
    show_frames:
      enable: False
      frame_count: 20
```
would throw an error because of the `debug` configuration options. The method `camera.py::__init__` expects every key in this dictionary to be an attribute of `gymapi.CameraProperties`.

This code change now only sets the attribute if it is contained with the `gymapi.CameraProperties` dictionary.

Tested and confirmed on my system. No regressions were introduced.

This PR also contains whitespace removal for the `camera.py` file.